### PR TITLE
Sidebar Navigation: Arrow should point to the right when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -22,7 +22,11 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={isCollapsed ? styles.icon : styles.collapsedIcon}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -29,4 +29,12 @@
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+  transition: transform 0.3s ease;
+  transform: rotate(180deg);
+}
+
+.collapsedIcon {
+  width: space.$s6;
+  margin-right: space.$s3;
+  transition: transform 0.3s ease;
 }


### PR DESCRIPTION
added transform and transition to .icon class to enable right-facing arrow when left nav menu is collapsed