### PR TITLE
Project list doesn’t show correct status

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -5,9 +5,9 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  stable = "info",
   warning = "warning",
-  critical = "critical",
+  error = "error",
 }
 
 export type Project = {

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,4 +1,4 @@
-import capitalize from "lodash/capitalize";
+import { ProjectStatus } from "@api/projects.types";
 import mockProjects from "../fixtures/projects.json";
 
 describe("Project List", () => {
@@ -22,6 +22,11 @@ describe("Project List", () => {
 
     it("renders the projects", () => {
       const languageNames = ["React", "Node.js", "Python"];
+      const statusToText = {
+        [ProjectStatus.stable]: "Stable",
+        [ProjectStatus.warning]: "Warning",
+        [ProjectStatus.error]: "Critical",
+      };
 
       // get all project cards
       cy.get('[data-cy="main-content-container"]')
@@ -32,7 +37,8 @@ describe("Project List", () => {
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          const status = mockProjects[index].status as ProjectStatus;
+          cy.wrap($el).contains(statusToText[status]);
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -33,7 +33,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: ProjectStatus.error,
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import capitalize from "lodash/capitalize";
 import { Badge, BadgeColor } from "@features/ui";
 import { Routes } from "@config/routes";
 import { ProjectLanguage, ProjectStatus } from "@api/projects.types";
@@ -19,7 +18,13 @@ const languageNames = {
 const statusColors = {
   [ProjectStatus.stable]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
-  [ProjectStatus.critical]: BadgeColor.error,
+  [ProjectStatus.error]: BadgeColor.error,
+};
+
+const statusToText = {
+  [ProjectStatus.stable]: "Stable",
+  [ProjectStatus.warning]: "Warning",
+  [ProjectStatus.error]: "Critical",
 };
 
 export function ProjectCard({ project }: ProjectCardProps) {
@@ -50,7 +55,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <div className={styles.issuesNumber}>{numEvents24h}</div>
           </div>
           <div className={styles.status}>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[status]}>{statusToText[status]}</Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The color of the status badge matches the project status
The text writes “Critical” for the error status and “Stable” for the info status
Covered with a Cypress test