### PR TITLE
“View issues” link in project card should direct to issues page with pre-selected project filter

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -31,6 +31,12 @@ describe("project list", () => {
         [ProjectStatus.error]: "Critical",
       };
 
+      const projectNameParams = [
+        "Frontend%20-%20Web%20Test",
+        "Backend",
+        "ML%20Service",
+      ];
+
       // loading animation should no longer exist in dom
       cy.get('[data-cy="loading-animation"]').should("not.exist");
 
@@ -47,7 +53,11 @@ describe("project list", () => {
           cy.wrap($el).contains(statusToText[status]);
           cy.wrap($el)
             .find("a")
-            .should("have.attr", "href", "/dashboard/issues");
+            .should(
+              "have.attr",
+              "href",
+              `/dashboard/issues?page=1&project=${projectNameParams[index]}`,
+            );
         });
     });
 

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -29,6 +29,9 @@ const statusToText = {
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const { name, language, numIssues, numEvents24h, status } = project;
+  const issuesFilterQuery = new URLSearchParams({
+    project: name,
+  });
 
   return (
     <div className={styles.container}>
@@ -60,7 +63,10 @@ export function ProjectCard({ project }: ProjectCardProps) {
         </div>
       </div>
       <div className={styles.bottomContainer}>
-        <Link href={Routes.issues} className={styles.viewIssuesAnchor}>
+        <Link
+          href={`${Routes.issues}?${issuesFilterQuery}`}
+          className={styles.viewIssuesAnchor}
+        >
           View issues
         </Link>
       </div>

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -29,9 +29,6 @@ const statusToText = {
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const { name, language, numIssues, numEvents24h, status } = project;
-  const issuesFilterQuery = new URLSearchParams({
-    project: name,
-  });
 
   return (
     <div className={styles.container}>
@@ -64,7 +61,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
       </div>
       <div className={styles.bottomContainer}>
         <Link
-          href={`${Routes.issues}?${issuesFilterQuery}`}
+          href={`${Routes.issues}?page=1&project=${name}`}
           className={styles.viewIssuesAnchor}
         >
           View issues


### PR DESCRIPTION

    The issues link opens the issues page with the correct filters pre-set
    Covered with a Cypress test
